### PR TITLE
Implement player management Phase 1: 

### DIFF
--- a/lib/controllers/GameController.ts
+++ b/lib/controllers/GameController.ts
@@ -6,7 +6,8 @@ module.exports.createGame = function createGame() {
 };
 
 module.exports.joinGame = function joinGame(context: ExegesisContext) {
-  return GameService.joinGame(context.params.path.id);
+  const username = context.user?.username;
+  return GameService.joinGame(context.params.path.id, username);
 };
 
 module.exports.postOrders = function postOrders(context: ExegesisContext) {

--- a/lib/test/GameService.test.ts
+++ b/lib/test/GameService.test.ts
@@ -59,6 +59,35 @@ describe("DefaultService", function () {
       assert.equal(firstResp.gameId, secondResp.gameId);
       assert.notEqual(firstResp.playerId, secondResp.playerId);
     });
+
+    it("should reject duplicate joins with same username", async () => {
+      const gameId = (await lgm.createGame()).id;
+      await lgm.joinGame(gameId, "testuser");
+      
+      try {
+        await lgm.joinGame(gameId, "testuser");
+        assert.fail("Expected error for duplicate join");
+      } catch (error) {
+        assert.equal(error.message, "Player already joined this game");
+      }
+    });
+
+    it("should reject joining full game", async () => {
+      const gameId = (await lgm.createGame()).id;
+      
+      // Fill the game to capacity (4 players)
+      await lgm.joinGame(gameId, "player1");
+      await lgm.joinGame(gameId, "player2");
+      await lgm.joinGame(gameId, "player3");
+      await lgm.joinGame(gameId, "player4");
+      
+      try {
+        await lgm.joinGame(gameId, "player5");
+        assert.fail("Expected error for full game");
+      } catch (error) {
+        assert.equal(error.message, "Game is full");
+      }
+    });
   });
 
   describe("listGames", () => {


### PR DESCRIPTION
player management Phase 1: joining limits and duplicate prevention

- Add MAX_PLAYERS_PER_GAME limit of 4 players per game
- Prevent duplicate joins by checking existing usernames
- Store username with player records for duplicate detection
- Update GameController to pass authenticated username
- Add comprehensive tests for new validation logic

🤖 Generated with [Claude Code](https://claude.ai/code)