### PR TITLE
feat: Replace text-based terrain with interactive hex grid

### DIFF
--- a/client/src/components/HexGrid.vue
+++ b/client/src/components/HexGrid.vue
@@ -1,0 +1,195 @@
+<template>
+  <svg :viewBox="viewBox" @click="handleSvgClick"> <!-- Changed click handler to svg specific -->
+    <g v-for="(hex, index) in hexes" :key="index" :transform="getHexTransform(hex)" @click.stop="handleHexClick(hex)"> <!-- Added click per hex, with stop propagation -->
+      <polygon
+        :points="getHexPoints(hex)"
+        :class="getHexClass(hex)"
+        :style="getHexStyle(hex)" />
+      <text
+        class="hex-text"
+        text-anchor="middle"
+        dy=".3em"
+        :font-size="getHexFontSize()">{{ getHexText(hex) }}</text>
+    </g>
+  </svg>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType, computed, ref } from 'vue'; // Added ref
+import { World, Terrain } from '../../../lib/service/Models';
+import { Hex, Point, Layout, OffsetCoord } from '../../../lib/Hex';
+
+interface HexStyle {
+  fill?: string;
+  stroke?: string;
+  strokeWidth?: number;
+}
+
+// Layout configuration
+const HEX_SIZE = 50; // Pixels
+const layout = new Layout(Layout.pointy, new Point(HEX_SIZE, HEX_SIZE), new Point(0, 0));
+
+export default defineComponent({
+  name: 'HexGrid',
+  props: {
+    world: {
+      type: Object as PropType<World>,
+      required: true,
+    },
+  },
+  setup(props) {
+    const offsetType = OffsetCoord.ODD;
+    const selectedHexRef = ref<Hex | null>(null);
+
+    const hexes = computed(() => {
+      const h: Hex[] = [];
+      if (!props.world.terrain) return h;
+      for (let r_offset = 0; r_offset < props.world.terrain.length; r_offset++) {
+        const rowTerrain = props.world.terrain[r_offset];
+        for (let q_offset = 0; q_offset < rowTerrain.length; q_offset++) {
+          h.push(OffsetCoord.roffsetToCube(offsetType, new OffsetCoord(q_offset, r_offset)));
+        }
+      }
+      return h;
+    });
+
+    const viewBox = computed(() => {
+      if (hexes.value.length === 0) return "0 0 100 100";
+      const allPoints: Point[] = [];
+      hexes.value.forEach(hex => {
+        layout.polygonCorners(hex).forEach(p => allPoints.push(p)); // Changed Layout. to layout.
+      });
+      if (allPoints.length === 0) return "0 0 100 100";
+      const minX = Math.min(...allPoints.map(p => p.x));
+      const minY = Math.min(...allPoints.map(p => p.y));
+      const maxX = Math.max(...allPoints.map(p => p.x));
+      const maxY = Math.max(...allPoints.map(p => p.y));
+      const padding = HEX_SIZE * 0.5;
+      return `${minX - padding} ${minY - padding} ${maxX - minX + padding * 2} ${maxY - minY + padding * 2}`;
+    });
+
+    const getHexPoints = (hex: Hex): string => {
+      return layout.polygonCorners(hex).map(p => `${p.x},${p.y}`).join(' '); // Changed Layout. to layout.
+    };
+
+    const getHexTransform = (hex: Hex): string => ''; // Points are absolute
+
+    const getTerrainTypeForHex = (hex: Hex): Terrain | null => {
+      const offsetCoord = OffsetCoord.roffsetFromCube(offsetType, hex);
+      const col = offsetCoord.col;
+      const row = offsetCoord.row;
+      if (props.world.terrain && row >= 0 && row < props.world.terrain.length && col >= 0 && col < props.world.terrain[row].length) {
+        return props.world.terrain[row][col];
+      }
+      return null;
+    };
+
+    const getHexStyle = (hex: Hex): HexStyle => {
+      const style: HexStyle = {};
+      const terrainType = getTerrainTypeForHex(hex);
+
+      // Only set fill based on terrain. Selection styling is handled by CSS class.
+      switch (terrainType) {
+        case Terrain.BLOCKED:
+          style.fill = '#5D6D7E'; // Darker grey for blocked
+          break;
+        case Terrain.EMPTY:
+          style.fill = '#EAECEE'; // Lighter grey for empty
+          break;
+        default:
+          style.fill = 'transparent'; // Should not happen for known terrain
+          break;
+      }
+      return style;
+    };
+
+    const getHexClass = (hex: Hex): string[] => {
+        const classes = ['hex-polygon'];
+        const terrainType = getTerrainTypeForHex(hex);
+
+        // Add class for terrain type
+        if (terrainType === Terrain.EMPTY) classes.push('terrain-empty');
+        if (terrainType === Terrain.BLOCKED) classes.push('terrain-blocked');
+
+        if (selectedHexRef.value && selectedHexRef.value.q === hex.q && selectedHexRef.value.r === hex.r && selectedHexRef.value.s === hex.s) {
+            classes.push('selected');
+        }
+        return classes;
+    };
+
+
+    const getHexText = (hex: Hex): string => `${hex.q},${hex.r}`;
+    const getHexFontSize = (): number => layout.size.x / 3.8;
+
+    const handleHexClick = (hex: Hex) => {
+      selectedHexRef.value = hex;
+      const offsetCoord = OffsetCoord.roffsetFromCube(offsetType, hex);
+      console.log('Clicked hex (axial):', hex.q, hex.r, hex.s, `- Terrain Index (offset col,row): ${offsetCoord.col},${offsetCoord.row}`);
+    };
+
+    const handleSvgClick = (event: MouseEvent) => {
+        // This handler is for clicks on the SVG background, not on a hex
+        // It can be used to deselect a hex, for example
+        if (event.target === event.currentTarget) { // ensure click was directly on SVG, not propagated from a hex
+            selectedHexRef.value = null;
+            console.log('Clicked SVG background, deselected hex.');
+        }
+    };
+
+    return {
+      hexes,
+      selectedHexRef, // Expose for template if needed, though direct manipulation is via methods
+      viewBox,
+      getHexPoints,
+      getHexTransform,
+      getHexStyle,
+      getHexClass,
+      getHexText,
+      getHexFontSize,
+      handleHexClick,
+      handleSvgClick,
+    };
+  },
+});
+</script>
+
+<style scoped>
+svg {
+  width: 100%;
+  height: auto;
+  border: 1px solid #d1d1d1; /* Lighter border for the SVG container */
+  background-color: #f8f9fa; /* Light background for the SVG area */
+}
+
+.hex-polygon {
+  stroke: #34495E; /* Default stroke color for hexes */
+  stroke-width: 1;
+  cursor: pointer;
+  transition: fill-opacity 0.2s ease-in-out, stroke-width 0.2s ease-in-out;
+}
+
+.hex-polygon:hover {
+  fill-opacity: 0.8; /* Make hex slightly more transparent on hover */
+}
+
+.hex-polygon.selected {
+    stroke: #c0392b; /* A strong red for selection stroke */
+    stroke-width: 2.5; /* Clearly thicker stroke */
+}
+
+/* Specific terrain styling via classes (alternative to inline styles from getHexStyle) */
+/* If getHexStyle is preferred for fill, these can be removed or be supplementary */
+.terrain-empty {
+  /* fill: #EAECEE; */ /* Example if using class-based fill */
+}
+.terrain-blocked {
+  /* fill: #5D6D7E; */ /* Example if using class-based fill */
+}
+
+.hex-text {
+  pointer-events: none; /* Text should not block clicks on the polygon */
+  fill: #2c3e50; /* Darker text color for better contrast */
+  font-weight: 500; /* Slightly bolder text */
+  font-family: 'Arial', sans-serif; /* Consistent font */
+}
+</style>

--- a/client/src/components/__tests__/HexGrid.spec.ts
+++ b/client/src/components/__tests__/HexGrid.spec.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, VueWrapper } from '@vue/test-utils';
+import HexGrid from '../HexGrid.vue';
+import { Terrain, type World } from '../../../../lib/service/Models'; // Adjusted path
+import { Hex } from '../../../../lib/Hex'; // Adjusted path
+
+// Mock console.log
+const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+describe('HexGrid.vue', () => {
+  let wrapper: VueWrapper<any>;
+
+  const createWorld = (terrain: Terrain[][]): World => ({
+    id: 1,
+    actors: [],
+    terrain,
+  });
+
+  beforeEach(() => {
+    consoleLogSpy.mockClear();
+  });
+
+  const mountComponent = (world: World | null) => {
+    return mount(HexGrid, {
+      props: {
+        world: world,
+      },
+    });
+  };
+
+  describe('Rendering Tests', () => {
+    it('renders no hexes if world.terrain is empty or undefined', () => {
+      const world = createWorld([]);
+      wrapper = mountComponent(world);
+      expect(wrapper.findAll('polygon').length).toBe(0);
+
+      // Test with undefined world prop or world with undefined terrain
+      // wrapper = mountComponent(null); // Component expects world object, v-if handles this in parent
+      // expect(wrapper.findAll('polygon').length).toBe(0);
+      // wrapper = mountComponent({ id:1, actors: [], terrain: undefined });
+      // expect(wrapper.findAll('polygon').length).toBe(0);
+    });
+
+    it('renders the correct number of hexes based on world.terrain data', () => {
+      const terrain = [
+        [Terrain.EMPTY, Terrain.BLOCKED],
+        [Terrain.EMPTY, Terrain.EMPTY],
+      ];
+      const world = createWorld(terrain);
+      wrapper = mountComponent(world);
+      expect(wrapper.findAll('polygon').length).toBe(4); // 2x2 grid
+    });
+
+    it('assigns correct styles/classes based on terrain type', async () => {
+      const terrain = [
+        [Terrain.EMPTY, Terrain.BLOCKED],
+      ];
+      const world = createWorld(terrain);
+      wrapper = mountComponent(world);
+
+      const polygons = wrapper.findAll('polygon');
+      expect(polygons.length).toBe(2);
+
+      // Hex 0,0 (offset) -> EMPTY
+      // Hex 1,0 (offset) -> BLOCKED
+
+      // Note: Accessing style directly can be tricky if it's complex or purely class-driven.
+      // We are using inline styles for fill, and classes for state.
+      // The component's getHexStyle sets fill directly.
+      // The component's getHexClass adds 'terrain-empty' or 'terrain-blocked'.
+
+      const firstHexElement = polygons[0];
+      const secondHexElement = polygons[1];
+
+      // Check classes (more robust)
+      expect(firstHexElement.classes()).toContain('terrain-empty');
+      expect(secondHexElement.classes()).toContain('terrain-blocked');
+
+      // Check inline fill style (if still applied, otherwise check effective style via classes)
+      // This depends on the internal functions getHexStyle being testable or relying on output.
+      // For now, we trust getHexStyle sets the fill, and classes are for other states.
+      // Let's check the style attribute directly:
+      expect(firstHexElement.attributes('style')).toContain('fill: #EAECEE;'); // #EAECEE
+      expect(secondHexElement.attributes('style')).toContain('fill: #5D6D7E;'); // #5D6D7E
+    });
+  });
+
+  describe('Interaction Tests', () => {
+    it('clicking a hex applies .selected class and logs coordinates', async () => {
+      const terrain = [[Terrain.EMPTY]];
+      const world = createWorld(terrain);
+      wrapper = mountComponent(world);
+
+      const polygon = wrapper.find('polygon');
+      await polygon.trigger('click');
+
+      expect(polygon.classes()).toContain('selected');
+
+      // Expected axial for odd-r (0,0) is (0,0,0)
+      // Click log: Clicked hex (axial): Q R S - Terrain Index (offset col,row): COL,ROW
+      // s coordinate can be -0 if q and r are 0.
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        'Clicked hex (axial):', 0, 0, -0, '- Terrain Index (offset col,row): 0,0'
+      );
+    });
+
+    it('clicking another hex moves the .selected class', async () => {
+        const terrain = [[Terrain.EMPTY, Terrain.BLOCKED]];
+        const world = createWorld(terrain);
+        wrapper = mountComponent(world);
+
+        const polygons = wrapper.findAll('polygon');
+        const firstHex = polygons[0];
+        const secondHex = polygons[1];
+
+        await firstHex.trigger('click');
+        expect(firstHex.classes()).toContain('selected');
+        expect(secondHex.classes()).not.toContain('selected');
+        consoleLogSpy.mockClear(); // Clear logs from first click
+
+        await secondHex.trigger('click');
+        expect(firstHex.classes()).not.toContain('selected');
+        expect(secondHex.classes()).toContain('selected');
+
+        // Hex 1,0 (offset col, row) for odd-r: q = 1 - (0 - (0&1))/2 = 1; r = 0. Axial (1,0,-1)
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          'Clicked hex (axial):', 1, 0, -1, '- Terrain Index (offset col,row): 1,0'
+        );
+      });
+
+    it('clicking SVG background deselects the current hex', async () => {
+      const terrain = [[Terrain.EMPTY]];
+      const world = createWorld(terrain);
+      wrapper = mountComponent(world);
+
+      const polygon = wrapper.find('polygon');
+      await polygon.trigger('click'); // Select a hex first
+      expect(polygon.classes()).toContain('selected');
+      consoleLogSpy.mockClear();
+
+      await wrapper.find('svg').trigger('click'); // Click on SVG element itself
+      expect(polygon.classes()).not.toContain('selected');
+      expect(consoleLogSpy).toHaveBeenCalledWith('Clicked SVG background, deselected hex.');
+    });
+  });
+
+  describe('Props Handling', () => {
+    it('updates rendering when world prop changes', async () => {
+      const initialWorld = createWorld([]);
+      wrapper = mountComponent(initialWorld);
+      expect(wrapper.findAll('polygon').length).toBe(0);
+
+      const newTerrain = [
+        [Terrain.EMPTY, Terrain.BLOCKED],
+        [Terrain.EMPTY, Terrain.EMPTY],
+      ];
+      const newWorld = createWorld(newTerrain);
+      await wrapper.setProps({ world: newWorld });
+
+      expect(wrapper.findAll('polygon').length).toBe(4);
+      // Check if one of the new hexes has the correct class/style
+      const firstHex = wrapper.findAll('polygon')[0];
+      expect(firstHex.classes()).toContain('terrain-empty');
+      expect(firstHex.attributes('style')).toContain('fill: #EAECEE;');
+    });
+
+    it('renders correctly with various terrain configurations', () => {
+        // All blocked
+        let terrain = [[Terrain.BLOCKED, Terrain.BLOCKED]];
+        let world = createWorld(terrain);
+        wrapper = mountComponent(world);
+        let polygons = wrapper.findAll('polygon');
+        expect(polygons.length).toBe(2);
+        expect(polygons[0].classes()).toContain('terrain-blocked');
+        expect(polygons[1].classes()).toContain('terrain-blocked');
+
+        // Mixed
+        terrain = [[Terrain.EMPTY, Terrain.BLOCKED, Terrain.EMPTY]];
+        world = createWorld(terrain);
+        wrapper = mountComponent(world);
+        polygons = wrapper.findAll('polygon');
+        expect(polygons.length).toBe(3);
+        expect(polygons[0].classes()).toContain('terrain-empty');
+        expect(polygons[1].classes()).toContain('terrain-blocked');
+        expect(polygons[2].classes()).toContain('terrain-empty');
+    });
+  });
+});

--- a/client/src/views/GameView.vue
+++ b/client/src/views/GameView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watchEffect } from 'vue'
+import HexGrid from '@/components/HexGrid.vue';
 import { useUserStore } from '../stores/User.store'
 import { useGamesStore, type Actor } from '../stores/Games.store'
 import { API_URL } from '@/main';
@@ -70,11 +71,10 @@ const response = await fetch(`${API_URL}/games/${g.gameId}/turns/${g.turn}/playe
       
       <div class="main-panel">
         <h3>World</h3>
-        <div class="world-grid">
-          <div v-for="row in game.world?.terrain || []" class="terrain-row">
-            <span>{{ row.join(' ').replaceAll('0', '.').replaceAll('1','X') }}</span>
-          </div>
+        <div class="world-grid" v-if="game.world">
+          <hex-grid :world="game.world" />
         </div>
+        <div v-else>Loading world data...</div>
         
         <h3>Actors</h3>
         <div class="actors-list">
@@ -128,16 +128,16 @@ const response = await fetch(`${API_URL}/games/${g.gameId}/turns/${g.turn}/playe
 }
 
 .world-grid {
-  font-family: monospace;
+  /* font-family: monospace; // Keep or remove based on HexGrid's text styling */
   background: #f9f9f9;
   padding: 10px;
   border-radius: 5px;
   margin-bottom: 20px;
+  /* The HexGrid component will manage its own internal layout and sizing. */
+  /* Ensure this container doesn't overly constrain it or add conflicting styles. */
 }
 
-.terrain-row {
-  line-height: 1.2;
-}
+/* .terrain-row styling is no longer needed as HexGrid handles its own rendering. */
 
 .actors-list {
   font-family: monospace;


### PR DESCRIPTION
Replaces the existing text-based rendering of the game world with a new interactive SVG-based hexagonal grid.

Key changes:
- Added a new Vue component `HexGrid.vue` responsible for rendering the hex grid.
- The component uses `lib/Hex.ts` for hex logic and calculations.
- Hexes are rendered as SVG polygons.
- Terrain types are visually distinguished using different fill colors.
- Hexes are clickable, and the selected hex is highlighted. Clicking a hex logs its axial and offset coordinates to the console.
- Integrated `HexGrid.vue` into `GameView.vue`, replacing the old text-based display.
- Added comprehensive unit tests for `HexGrid.vue` using Vitest, covering rendering logic and user interactions.