### PR TITLE
🎨 Palette: Improve accessibility of move removal in OrderSubmission

### DIFF
--- a/client/src/components/OrderSubmission.vue
+++ b/client/src/components/OrderSubmission.vue
@@ -10,7 +10,13 @@
           Move Actor {{ move.actorId }} from ({{ move.startPos.x }}, {{ move.startPos.y }})
           to ({{ move.endPos.x }}, {{ move.endPos.y }})
         </span>
-        <button @click="handleRemoveMove(move)" class="remove-move-btn">Remove</button>
+        <button
+          @click="handleRemoveMove(move)"
+          class="remove-move-btn"
+          :aria-label="`Remove move for Actor ${move.actorId} to (${move.endPos.x}, ${move.endPos.y})`"
+        >
+          Remove
+        </button>
       </li>
     </ul>
     <button

--- a/client/src/components/__tests__/OrderSubmissionA11y.spec.ts
+++ b/client/src/components/__tests__/OrderSubmissionA11y.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import OrderSubmission from '../OrderSubmission.vue';
+import type { PlannedMove } from '../../stores/Games.store';
+
+const sampleMoves: PlannedMove[] = [
+  { actorId: 101, startPos: { x: 0, y: 0 }, endPos: { x: 1, y: 0 } },
+  { actorId: 102, startPos: { x: 2, y: 1 }, endPos: { x: 2, y: 2 } },
+];
+
+describe('OrderSubmission.vue accessibility', () => {
+  it('renders "Remove" button with correct aria-label for each move', () => {
+    const wrapper = mount(OrderSubmission, {
+      props: { plannedMoves: sampleMoves }
+    });
+
+    const removeButtons = wrapper.findAll('button.remove-move-btn');
+    expect(removeButtons.length).toBe(sampleMoves.length);
+
+    sampleMoves.forEach((move, index) => {
+      const expectedAriaLabel = `Remove move for Actor ${move.actorId} to (${move.endPos.x}, ${move.endPos.y})`;
+      expect(removeButtons[index].attributes('aria-label')).toBe(expectedAriaLabel);
+    });
+  });
+});


### PR DESCRIPTION
Added a dynamic `:aria-label` to the "Remove" button in `OrderSubmission.vue` to describe exactly which move is being removed. This provides unique context for screen reader users when navigating a list of multiple "Remove" buttons.

♿ Accessibility:
- Added descriptive ARIA labels to list-item action buttons.
- Ensured the label includes the actor ID and destination coordinates for clear identification.

---
*PR created automatically by Jules for task [15601996242680483300](https://jules.google.com/task/15601996242680483300) started by @bmordue*